### PR TITLE
feat: 添加oneid登出时，清除后端token的逻辑

### DIFF
--- a/src/oneid-app/loginMixin.ts
+++ b/src/oneid-app/loginMixin.ts
@@ -95,6 +95,7 @@ export default class LoginMixin extends Vue {
   }
 
   async logout() {
+    await api.UCenter.revokeToken();
     await api.logout();
     this.doLogout();
   }

--- a/src/services/oneid.ts
+++ b/src/services/oneid.ts
@@ -579,6 +579,12 @@ export class UCenter extends API {
     return user;
   }
 
+  static async revokeToken() {
+    const url = '/siteapi/oneid/revoke/token/';
+    const resp = await http.post(url);
+    return resp.data;
+  }
+
   static async apps() {
     return http.get(this.url({action: 'apps'})).then(x => x.data);
   }


### PR DESCRIPTION
添加oneid登出时，清除后端token的逻辑